### PR TITLE
Add Dockerfile and OpenAI-compatible API service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,89 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+
+# CI
+.codeclimate.yml
+.travis.yml
+.taskcluster.yml
+
+# Docker
+docker-compose.yml
+Dockerfile
+.docker
+.dockerignore
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual environment
+.env
+.venv/
+venv/
+
+# PyCharm
+.idea
+
+# Python mode for VIM
+.ropeproject
+**/.ropeproject
+
+# Vim swap files
+**/*.swp
+
+# VS Code
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+WORKDIR /breezyvoice
+
+ENV UV_LINK_MODE=copy
+ENV PATH="/root/.local/bin/:$PATH"
+
+ADD https://astral.sh/uv/install.sh /uv-installer.sh
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates ffmpeg&& \
+    sh /uv-installer.sh && rm /uv-installer.sh && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    uv venv -p 3.10
+
+COPY . .
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install -r requirements.txt --index-strategy unsafe-best-match
+
+EXPOSE 8080
+
+ENTRYPOINT ["/breezyvoice/.venv/bin/python"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,12 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     uv venv -p 3.10
 
-COPY . .
+COPY requirements.txt /breezyvoice/requirements.txt
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install -r requirements.txt --index-strategy unsafe-best-match
+
+COPY . .
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,15 @@ python batch_inference.py \
   --output_audio_folder ./results
 ```
 
+### Docker and OpenAI Compatible API
+
+``` bash
+$ docker compose up -d --build
+# after the container is up
+$ pip install openai
+$ python openai_api_inference.py
+```
+
 ---
 
 If you like our work, please cite:

--- a/api.py
+++ b/api.py
@@ -1,0 +1,103 @@
+# OpenAI API Spec. Reference: https://platform.openai.com/docs/api-reference/audio/createSpeech
+
+from contextlib import asynccontextmanager
+from io import BytesIO
+
+import torchaudio
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from g2pw import G2PWConverter
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
+
+from cosyvoice.utils.file_utils import load_wav
+from single_inference import CustomCosyVoice, get_bopomofo_rare
+
+
+class Settings(BaseSettings):
+    api_key: str = Field(
+        default="", description="Specifies the API key used to authenticate the user."
+    )
+
+    model_path: str = Field(
+        default="MediaTek-Research/BreezyVoice-300M",
+        description="Specifies the model used for speech synthesis.",
+    )
+    speaker_prompt_audio_path: str = Field(
+        default="./data/example.wav",
+        description="Specifies the path to the prompt speech audio file of the speaker.",
+    )
+    speaker_prompt_text_transcription: str = Field(
+        default="在密碼學中，加密是將明文資訊改變為難以讀取的密文內容，使之不可讀的方法。",
+        description="Specifies the transcription of the speaker prompt audio.",
+    )
+
+
+class SpeechRequest(BaseModel):
+    model: str = ""
+    input: str = Field(
+        description="The content that will be synthesized into speech. You can include phonetic symbols if needed, though they should be used sparingly.",
+        examples=["今天天氣真好"],
+    )
+    response_format: str = ""
+    speed: float = 1.0
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    app.state.settings = Settings()
+    app.state.cosyvoice = CustomCosyVoice(app.state.settings.model_path)
+    app.state.bopomofo_converter = G2PWConverter()
+    app.state.prompt_speech_16k = load_wav(
+        app.state.settings.speaker_prompt_audio_path, 16000
+    )
+    yield
+    del app.state.cosyvoice
+    del app.state.bopomofo_converter
+
+
+app = FastAPI(lifespan=lifespan, root_path="/v1")
+
+
+@app.get("/models")
+async def get_models():
+    return {"message": "List of available models"}
+
+
+@app.post("/audio/speech")
+async def speach_endpoint(request: SpeechRequest):
+    ###normalization
+    speaker_prompt_text_transcription = (
+        request.app.state.cosyvoice.frontend.text_normalize_new(
+            request.app.state.speaker_prompt_text_transcription, split=False
+        )
+    )
+    content_to_synthesize = request.app.state.cosyvoice.frontend.text_normalize_new(
+        request.input, split=False
+    )
+    speaker_prompt_text_transcription_bopomo = get_bopomofo_rare(
+        speaker_prompt_text_transcription, app.state.bopomofo_converter
+    )
+
+    content_to_synthesize_bopomo = get_bopomofo_rare(
+        content_to_synthesize, app.state.bopomofo_converter
+    )
+    output = app.state.cosyvoice.inference_zero_shot_no_normalize(
+        content_to_synthesize_bopomo,
+        speaker_prompt_text_transcription_bopomo,
+        app.state.prompt_speech_16k,
+    )
+    audio_buffer = BytesIO()
+    torchaudio.save(audio_buffer, output["tts_speech"], 22050, format="wav")
+    audio_buffer.seek(0)
+    return StreamingResponse(
+        audio_buffer,
+        media_type="audio/wav",
+        headers={"Content-Disposition": "attachment; filename=output.wav"},
+    )
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("api:app", host="0.0.0.0", port=8080)

--- a/api.py
+++ b/api.py
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
     )
 
     model_path: str = Field(
-        default="MediaTek-Research/BreezyVoice-300M",
+        default="MediaTek-Research/BreezyVoice",
         description="Specifies the model used for speech synthesis.",
     )
     speaker_prompt_audio_path: str = Field(

--- a/api.py
+++ b/api.py
@@ -60,8 +60,18 @@ app = FastAPI(lifespan=lifespan, root_path="/v1")
 
 
 @app.get("/models")
-async def get_models():
-    return {"message": "List of available models"}
+async def get_models(request: Request):
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": request.app.state.settings.model_path,
+                "object": "model",
+                "created": 0,
+                "owned_by": "local",
+            }
+        ],
+    }
 
 
 @app.post("/audio/speech")

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,6 @@
 services:
   app:
+    image: breezyvoice:latest
     build: .
     ports:
       - "8080:8080"

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,4 +8,4 @@ services:
     command: api.py
 
 volumes:
-  hf-cache
+  hf-cache:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,11 @@
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - hf-cache:/root/.cache/huggingface/
+    command: api.py
+
+volumes:
+  hf-cache

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,7 @@ services:
     volumes:
       - hf-cache:/root/.cache/huggingface/
     command: api.py
+    init: true
     deploy:
       resources:
         reservations:

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,12 @@ services:
     volumes:
       - hf-cache:/root/.cache/huggingface/
     command: api.py
-
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
 volumes:
   hf-cache:

--- a/openai_api_inference.py
+++ b/openai_api_inference.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+import openai
+
+client = openai.Client(base_url="http://localhost:8080", api_key="sk-template")
+
+speech_file_path = Path(__file__).parent / "./results/speech.wav"
+response = client.audio.speech.create(
+    model="tts-1",
+    voice="alloy",
+    input="冷氣團南下 北部轉涼白天氣溫降8度",
+)
+
+with open(speech_file_path, "wb") as audio_file:
+    audio_file.write(response.content)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ onnxruntime-gpu==1.16.0; sys_platform == 'linux'
 openai-whisper==20231117
 protobuf==4.25
 pydantic==2.7.0
+pydantic-settings==2.7.0
 rich==13.7.1
 soundfile==0.12.1
 tensorboard==2.14.0


### PR DESCRIPTION
1. Added `Dockerfile` to containerize the environment, making deployment and usage more convenient and consistent.

```bash
$ docker build -t breezyvoice .
$ docker run --rm --gpus all --entrypoint "" -ti breezyvoice bash
root@be7fcdc371ad:/breezyvoice# .venv/bin/python single_inference.py -h
```

2. Added `api.py`: An Online Inference Server Compatible with OpenAI API

```bash
$ docker compose up -d --build
$ dc logs -f 
...
app-1  | INFO:     Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
$ pip install openai
$ python openai_api_inference.py
$ ls -lh ./results/speech.wav
```

3. Some features are not yet implemented, including API key authentication, file format conversion using ffmpeg, and speed adjustment. 